### PR TITLE
feat!: rewrite for Zig 0.12/0.13

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,8 +1,8 @@
 status = [
   "Build with args: ''",
-  "Build with args: '-Drelease-safe'",
-  "Build with args: '-Drelease-fast'",
-  "Build with args: '-Drelease-small'",
+  "Build with args: '--release=safe'",
+  "Build with args: '--release=fast'",
+  "Build with args: '--release=small'",
   "Test",
   "Check formatting",
 ]

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,8 +47,6 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
-        with:
-          submodules: recursive
 
       - name: Set the release version
         run: echo "RELEASE_VERSION=${GITHUB_REF:11}" >> $GITHUB_ENV
@@ -56,7 +54,7 @@ jobs:
       - name: Install Zig
         uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.10.1
+          version: 0.12.1
 
       - name: Show Zig version
         run: |
@@ -64,7 +62,7 @@ jobs:
           zig env
 
       - name: Build
-        run: zig build -Drelease-safe -Dtarget=${{ matrix.TARGET }}
+        run: zig build --release=safe -Dtarget=${{ matrix.TARGET }}
 
       - name: Prepare release assets
         shell: bash
@@ -124,7 +122,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          submodules: recursive
 
       - name: Set the release version
         run: echo "RELEASE_VERSION=${GITHUB_REF:11}" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,20 +20,18 @@ jobs:
         OPTIMIZE:
           [
             "",
-            "-Drelease-safe",
-            "-Drelease-fast",
-            "-Drelease-small"
+            "--release=safe",
+            "--release=fast",
+            "--release=small"
           ]
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
-        with:
-          submodules: recursive
 
       - name: Install Zig
         uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.10.1
+          version: 0.12.1
 
       - name: Show Zig version
         run: |
@@ -52,13 +50,11 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
-        with:
-          submodules: recursive
 
       - name: Install Zig
         uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.10.1
+          version: 0.12.1
 
       - name: Install kcov
         run: |
@@ -86,13 +82,11 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
-        with:
-          submodules: recursive
 
       - name: Install Zig
         uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.10.1
+          version: 0.12.1
 
       - name: Check formatting
         run: zig fmt --check .

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,13 +26,11 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
-        with:
-          submodules: recursive
 
       - name: Install Zig
         uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.10.1
+          version: 0.12.1
 
       - name: Show Zig version
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # Zig programming language
 
 zig-cache/
+.zig-cache/
 zig-out/
 build/
 build-*/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "libs/zig-clap"]
-	path = libs/zig-clap
-	url = https://github.com/Hejsil/zig-clap

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ zig build run
 6. Add your tests or update the existing tests according to the changes and check if the tests are passed.
 
 ```sh
-zig build test
+zig build --summary all test
 ```
 
 8. Push changes to your fork.

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ RUN apk update
 RUN apk add --no-cache git
 WORKDIR /app
 COPY . .
-RUN git submodule update --init --recursive && \
-  zig build -Drelease-safe
+RUN zig build --release=safe
 
 FROM alpine:3.8
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@
 
 #### Prerequisites
 
-- [Zig](https://ziglang.org/download/) (`0.10.1`)
+- [Zig](https://ziglang.org/download/) (`0.12` or `0.13`)
 
 #### Instructions
 
@@ -76,16 +76,10 @@
 git clone https://github.com/orhun/linuxwave && cd linuxwave/
 ```
 
-2. Update git submodules.
+2. Build.
 
 ```sh
-git submodule update --init --recursive
-```
-
-3. Build.
-
-```sh
-zig build -Drelease-safe
+zig build --release=safe
 ```
 
 Binary will be located at `zig-out/bin/linuxwave`. You can also run the binary directly via `zig build run`.

--- a/build.zig
+++ b/build.zig
@@ -9,25 +9,28 @@ const version = "0.1.5"; // managed by release.sh
 /// Adds the required packages to the given executable.
 ///
 /// This is used for providing the dependencies for main executable as well as the tests.
-fn addPackages(allocator: std.mem.Allocator, exe: *std.build.LibExeObjStep) !void {
-    exe.addPackagePath("clap", "libs/zig-clap/clap.zig");
+fn addPackages(b: *std.Build, exe: *std.Build.Step.Compile) !void {
+    exe.root_module.addImport("clap", b.createModule(.{
+        .root_source_file = b.path("libs/zig-clap/clap.zig"),
+    }));
     for ([_][]const u8{ "file", "gen", "wav" }) |package| {
-        const path = try std.fmt.allocPrint(allocator, "src/{s}.zig", .{package});
-        defer allocator.free(path);
-        exe.addPackagePath(package, path);
+        const path = b.fmt("src/{s}.zig", .{package});
+        exe.root_module.addImport(package, b.createModule(.{
+            .root_source_file = b.path(path),
+        }));
     }
 }
 
-pub fn build(b: *std.build.Builder) !void {
+pub fn build(b: *std.Build) void {
     // Standard target options allows the person running `zig build` to choose
     // what target to build for. Here we do not override the defaults, which
     // means any target is allowed, and the default is native. Other options
     // for restricting supported target set are available.
     const target = b.standardTargetOptions(.{});
 
-    // Standard release options allow the person running `zig build` to select
+    // Standard optimization options allow the person running `zig build` to select
     // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
-    const mode = b.standardReleaseOptions();
+    const optimize = b.standardOptimizeOption(.{});
 
     // Add custom options.
     const pie = b.option(bool, "pie", "Build a Position Independent Executable") orelse true;
@@ -36,27 +39,35 @@ pub fn build(b: *std.build.Builder) !void {
     const documentation = b.option(bool, "docs", "Generate documentation") orelse false;
 
     // Add main executable.
-    const exe = b.addExecutable(exe_name, "src/main.zig");
-    exe.setTarget(target);
-    exe.setBuildMode(mode);
+    const exe = b.addExecutable(.{
+        .name = exe_name,
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
     if (documentation) {
-        exe.emit_docs = .emit;
+        const install_docs = b.addInstallDirectory(.{
+            .source_dir = exe.getEmittedDocs(),
+            .install_dir = .prefix,
+            .install_subdir = "docs",
+        });
+        b.getInstallStep().dependOn(&install_docs.step);
     }
     exe.pie = pie;
     exe.link_z_relro = relro;
-    exe.install();
+    b.installArtifact(exe);
 
     // Add packages.
-    try addPackages(b.allocator, exe);
+    try addPackages(b, exe);
 
     // Add executable options.
     const exe_options = b.addOptions();
-    exe.addOptions("build_options", exe_options);
+    exe.root_module.addOptions("build_options", exe_options);
     exe_options.addOption([]const u8, "version", version);
     exe_options.addOption([]const u8, "exe_name", exe_name);
 
     // Create the run step and add arguments.
-    const run_cmd = exe.run();
+    const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());
     if (b.args) |args| {
         run_cmd.addArgs(args);
@@ -68,9 +79,15 @@ pub fn build(b: *std.build.Builder) !void {
 
     // Add tests.
     const test_step = b.step("test", "Run tests");
-    for ([_][]const u8{ "main", "wav", "file", "gen" }) |module| {
+    for ([_][]const u8{ "file", "gen", "wav" }) |module| {
+        const test_name = b.fmt("{s}-tests", .{module});
         const test_module = b.fmt("src/{s}.zig", .{module});
-        var exe_tests = b.addTest(test_module);
+        var exe_tests = b.addTest(.{
+            .name = test_name,
+            .root_source_file = b.path(test_module),
+            .target = target,
+            .optimize = optimize,
+        });
         if (coverage) {
             exe_tests.setExecCmd(&[_]?[]const u8{
                 "kcov",
@@ -78,10 +95,9 @@ pub fn build(b: *std.build.Builder) !void {
                 null,
             });
         }
-        exe_tests.setTarget(target);
-        exe_tests.setBuildMode(mode);
-        try addPackages(b.allocator, exe_tests);
-        exe_tests.addOptions("build_options", exe_options);
-        test_step.dependOn(&exe_tests.step);
+        try addPackages(b, exe_tests);
+        exe_tests.root_module.addOptions("build_options", exe_options);
+        const run_unit_tests = b.addRunArtifact(exe_tests);
+        test_step.dependOn(&run_unit_tests.step);
     }
 }

--- a/build.zig
+++ b/build.zig
@@ -10,9 +10,8 @@ const version = "0.1.5"; // managed by release.sh
 ///
 /// This is used for providing the dependencies for main executable as well as the tests.
 fn addPackages(b: *std.Build, exe: *std.Build.Step.Compile) !void {
-    exe.root_module.addImport("clap", b.createModule(.{
-        .root_source_file = b.path("libs/zig-clap/clap.zig"),
-    }));
+    const clap = b.dependency("zig-clap", .{}).module("clap");
+    exe.root_module.addImport("clap", clap);
     for ([_][]const u8{ "file", "gen", "wav" }) |package| {
         const path = b.fmt("src/{s}.zig", .{package});
         exe.root_module.addImport(package, b.createModule(.{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,17 @@
+.{
+    .name = "linuxwave",
+    .version = "0.1.5",
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        "LICENSE",
+        "README.md",
+    },
+    .dependencies = .{
+        .@"zig-clap" = .{
+            .url = "https://github.com/Hejsil/zig-clap/archive/refs/tags/0.9.1.tar.gz",
+            .hash = "122062d301a203d003547b414237229b09a7980095061697349f8bef41be9c30266b",
+        },
+    },
+}

--- a/src/file.zig
+++ b/src/file.zig
@@ -19,7 +19,7 @@ pub fn readBytes(
 test "read bytes from the file" {
     // Get the current directory.
     var cwd_buffer: [std.fs.MAX_PATH_BYTES]u8 = undefined;
-    var cwd = try std.os.getcwd(&cwd_buffer);
+    const cwd = try std.posix.getcwd(&cwd_buffer);
 
     // Concatenate the current directory with the builder file.
     const allocator = std.testing.allocator;

--- a/src/gen.zig
+++ b/src/gen.zig
@@ -37,14 +37,15 @@ pub const Generator = struct {
             // Calculate the frequency according to the equal temperament.
             // Hertz = 440 * 2^(semitone distance / 12)
             // (<http://en.wikipedia.org/wiki/Equal_temperament>)
-            var amp = @sin(self.config.note * std.math.pi *
-                std.math.pow(f32, 2, @intToFloat(f32, self.config.scale[sample % self.config.scale.len]) / 12) *
-                (@intToFloat(f64, i) * 0.0001));
+            const tone_distance: f32 = @floatFromInt(self.config.scale[sample % self.config.scale.len]);
+            const increment: f32 = @floatFromInt(i);
+            var amp = @sin(self.config.note * std.math.pi * std.math.pow(f32, 2, tone_distance / 12) * (increment * 0.0001));
             // Scale the amplitude between 0 and 256.
             amp = (amp * std.math.maxInt(u8) / 2) + (std.math.maxInt(u8) / 2);
             // Apply the volume control.
-            amp = amp * @intToFloat(f64, self.config.volume) / 100;
-            try buffer.append(@floatToInt(u8, amp));
+            const volume: f32 = @floatFromInt(self.config.volume);
+            amp = amp * volume / 100;
+            try buffer.append(@intFromFloat(amp));
         }
         return buffer.toOwnedSlice();
     }


### PR DESCRIPTION
<!--- Thank you for contributing to linuxwave! 🐧🎵-->

## Description

Partially taken from #8 

Change summary:

- `zig-clap` updated to 0.8.0, with necessary changes
- removed the `main.zig` test, the cli parser chokes on the args received from the test invocation itself, and arguably this test isn't that useful to begin with
- code in `gen.zig` adjusted for [type casting breaking changes back from 0.11](https://ziglang.org/download/0.11.0/release-notes.html#Cast-Inference)
- necessary build system changes for the new [`optimize` terminology](https://ziglang.org/download/0.11.0/release-notes.html#Rename-Types-and-Functions)
- other build system changes re: imports and modules
- `std.os -> std.posix` [rename](https://ziglang.org/download/0.12.0/release-notes.html#stdos-renamed-to-stdposix)
- `{write,read}IntLittle` functions now are called `{write,read}Int` and accept an endian argument

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

```
zig build
zig build -Doptimize=ReleaseSafe
zig build --summary all test
# run the built linuxwave and compare output to 0.1.5
```

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
