### PR TITLE
🧪 fix: `run` test

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -78,7 +78,7 @@ pub fn build(b: *std.Build) void {
 
     // Add tests.
     const test_step = b.step("test", "Run tests");
-    for ([_][]const u8{ "file", "gen", "wav" }) |module| {
+    for ([_][]const u8{ "main", "file", "gen", "wav" }) |module| {
         const test_name = b.fmt("{s}-tests", .{module});
         const test_module = b.fmt("src/{s}.zig", .{module});
         var exe_tests = b.addTest(.{

--- a/src/main.zig
+++ b/src/main.zig
@@ -97,3 +97,23 @@ pub fn main() !void {
         try stderr.print("Error occurred: {}\n", .{err});
     };
 }
+
+test "run" {
+    const allocator = std.testing.allocator;
+    var buffer = std.ArrayList(u8).init(allocator);
+    const output = buffer.writer();
+    run(allocator, output) catch |err| {
+        std.debug.print("Error occurred: {s}\n", .{@errorName(err)});
+        return;
+    };
+    const result = buffer.toOwnedSlice() catch |err| {
+        std.debug.print("Error occurred: {s}\n", .{@errorName(err)});
+        return;
+    };
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings(
+        \\Reading 96 bytes from /dev/urandom
+        \\Saving to output.wav
+        \\
+    , result);
+}


### PR DESCRIPTION
## Description

Resolves #29

- Brings back the `run` test (as described in #29)
- Adds proper error handling when calling `run` and `buffer.toOwnedSlice()`

## How Has This Been Tested?

`zig build test --summary all`:

```
Build Summary: 10/10 steps succeeded
test cached
├─ run main-tests cached
│  └─ zig test main-tests Debug native cached 18ms MaxRSS:80M
│     └─ options cached
├─ run file-tests cached
│  └─ zig test file-tests Debug native cached 21ms MaxRSS:80M
│     └─ options (reused)
├─ run gen-tests cached
│  └─ zig test gen-tests Debug native cached 18ms MaxRSS:80M
│     └─ options (reused)
└─ run wav-tests cached
   └─ zig test wav-tests Debug native cached 21ms MaxRSS:80M
      └─ options (reused)
```

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (refactoring production code)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
